### PR TITLE
Fix rounding error in percentage calculation in app

### DIFF
--- a/app/logitube.cpp
+++ b/app/logitube.cpp
@@ -56,8 +56,7 @@ void set_keys(double percent, std::string service) {
   for (unsigned int i = 1; i <= 12; i++) {
     // 100. / 12 because we map 0-100 to 1-12
     if (percent < 100. / 12) {
-      percent = percent / (8 + 1. / 3) * 100;
-      set_key(i, percent * 2.55, service);
+      set_key(i, percent * 12 * 2.55, service);
       break;
     }
     set_key(i, 255, service);

--- a/app/logitube.cpp
+++ b/app/logitube.cpp
@@ -54,13 +54,14 @@ void set_key(int key, double strength, std::string service) {
 void set_keys(double percent, std::string service) {
   system("g910-led -an 000000");
   for (unsigned int i = 1; i <= 12; i++) {
-    if (percent < 8 + 1. / 3) {
+    // 100. / 12 because we map 0-100 to 1-12
+    if (percent < 100. / 12) {
       percent = percent / (8 + 1. / 3) * 100;
       set_key(i, percent * 2.55, service);
       break;
     }
     set_key(i, 255, service);
-    percent -= 8 + 1. / 3;
+    percent -= 100. / 12;
   }
   system("g910-led -c");
 }

--- a/app/logitube.cpp
+++ b/app/logitube.cpp
@@ -54,13 +54,13 @@ void set_key(int key, double strength, std::string service) {
 void set_keys(double percent, std::string service) {
   system("g910-led -an 000000");
   for (unsigned int i = 1; i <= 12; i++) {
-    if (percent < 8 + 1 / 3) {
-      percent = percent / (8 + 1 / 3) * 100;
+    if (percent < 8 + 1. / 3) {
+      percent = percent / (8 + 1. / 3) * 100;
       set_key(i, percent * 2.55, service);
       break;
     }
     set_key(i, 255, service);
-    percent -= 8 + 1 / 3;
+    percent -= 8 + 1. / 3;
   }
   system("g910-led -c");
 }


### PR DESCRIPTION
Previously, I subtracted `8 + 1 / 3` in each loop iteration. Since C++ parses it 8 + (1/3) and 1 is an integer, 1/3 gets rounded down and results in 0. Thus, the whole equation results in 8, not in 8 + 1 / 3, mathematically. This PR could fix that by changing the respective lines to `8 + 1. / 3`. However, I decided to use the calculation I derived “8 + 1 / 3” from, 100 / 12, and add an explanatory comment on why this is done.

Plus, the percentage calculation for the only non-fully lit key has been simplified